### PR TITLE
Updating elux readme with new certificate information

### DIFF
--- a/eLux/README.md
+++ b/eLux/README.md
@@ -55,3 +55,13 @@ In this example, VerboseModules will show verbose level 1 webrtc logs and will f
 The logs can be found at `/var/log/kandy/`.
 
 ### 5. Known Issues / Limitations
+
+#### Known Issues
+- Internal VDI error when removing device while application is running. `KAJ-1006`
+
+#### Unreleased Fixes
+- Window can suddenly not be visible when opening and closing sessions multiple times. `KAJ-1007`
+- Quickly closing a session right after opening it will cause the VDI solution to freeze. `KAJ-1009`
+
+#### Limitation
+- Previous versions allowed for multiple sessions to be created without full support. Version 1.6.1 does not have multiple session support, it will be delivered in 1.7.

--- a/eLux/README.md
+++ b/eLux/README.md
@@ -6,15 +6,14 @@ This driver adds support for [Citrix Workspace App for Linux](https://docs.citri
 
 ### 1. eLux Package Signature
 
-You can download the following Root and Code Signing CA certificate from digicert
+Validating package signatures requires the following certificates from [Sectigo's main page](https://support.sectigo.com/articles/Knowledge/Sectigo-Intermediate-Certificates):
 
-DigiCert Assured ID Root CA:
+Root Certificate:<br>
+[AAA Certificate Services](https://comodoca.my.salesforce.com/sfc/p/1N000002Ljih/a/3l000000sYVG/4l82xrBbMv8Ndh.SBoUvQs0BjYk_pJlb4Sa92KfrsxY)
 
-https://cacerts.digicert.com/DigiCertAssuredIDRootCA.crt.pem
-
-DigiCert SHA2 Assured ID Code Signing CA:
-
-https://cacerts.digicert.com/DigiCertSHA2AssuredIDCodeSigningCA.crt.pem
+Intermediate Certificates:<br>
+[Sectigo Public Code Signing CA R36](https://comodoca.my.salesforce.com/sfc/p/#1N000002Ljih/a/3l000000oAhy/QCCby12C7cYo50nNyic6AuG1KFcwe1rDn1EknfTaUzY)<br>
+[SectigoPublicCodeSigningRootR46_AAA [ Cross Signed ]](https://comodoca.my.salesforce.com/sfc/p/1N000002Ljih/a/3l000000sYVB/t5kHfAZUjSL8NyXDwAQ3OhmfoTNSOnWgpnTmksjVyJc)
 
 ### 2. Browser Container Certificates
 
@@ -56,13 +55,3 @@ In this example, VerboseModules will show verbose level 1 webrtc logs and will f
 The logs can be found at `/var/log/kandy/`.
 
 ### 5. Known Issues / Limitations
-
-#### Known Issues
-- Internal VDI error when removing device while application is running. `KAJ-1006`
-
-#### Unreleased Fixes
-- Window can suddenly not be visible when opening and closing sessions multiple times. `KAJ-1007`
-- Quickly closing a session right after opening it will cause the VDI solution to freeze. `KAJ-1009`
-
-#### Limitation
-- Previous versions allowed for multiple sessions to be created without full support. Version 1.6.1 does not have multiple session support, it will be delivered in 1.7.


### PR DESCRIPTION
Since we received a new code signing certificate and used it to sign our software, new certificates are also now required on the Scout machine to validate the signatures on our packages. This PR updates the readme with new certificate info.

